### PR TITLE
[bug] fix token matching object prototype methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,10 @@ function tokenBase(stream: StringStream, state: State) {
       keywordsMoreBlockAndTransactionProperties,
       cur,
     ) ||
-    (cur in keywordsBlockAndTransactionProperties &&
+    (Object.prototype.propertyIsEnumerable.call(
+      keywordsBlockAndTransactionProperties,
+      cur,
+    ) &&
       ((keywordsBlockAndTransactionProperties as any)[cur] as Array<
         string
       >).some(function (item) {


### PR DESCRIPTION
Found an edge case where `toString` would snag on prototype methods.

<img width="580" alt="image" src="https://user-images.githubusercontent.com/7055455/200993732-d9c536dd-df8f-4938-ac3b-217368312dd6.png">

<img width="296" alt="image" src="https://user-images.githubusercontent.com/7055455/200994727-007d4fca-2d42-4edb-95b7-d5d891822c03.png">

